### PR TITLE
fixes sourcegraph/sourcegraph#1903

### DIFF
--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -284,8 +284,11 @@ export default class TypeScriptService {
         if (sourceFile) {
             return sourceFile;
         }
-        // HACK (alexsaveliev) using custom method to add a file        
+        // HACK (alexsaveliev) using custom method to add a file
+        configuration.host.incProjectVersion();
         configuration.program.addFile(fileName);
+        // requery program object to synchonize LanguageService's data
+        configuration.program = configuration.service.getProgram();
         return configuration.program.getSourceFile(fileName);
     }
 


### PR DESCRIPTION
- using `getProjectVersion` to tell TypeScript when `program` is changed (in our case it happens only when new files are added). By doing this we can be sure that our `program` object is up-to-date with the TypeScript's one.